### PR TITLE
Make helper methods with blocks work.

### DIFF
--- a/lib/bacon.rb
+++ b/lib/bacon.rb
@@ -218,8 +218,8 @@ module Bacon
     def describe(*args, &block)
       context = Bacon::Context.new(args.join(' '), &block)
       (parent_context = self).methods(false).each {|e|
-        (class << context; self; end).send(:define_method, e) { |*args2|
-          parent_context.send(e, *args2)
+        (class << context; self; end).send(:define_method, e) { |*args2, &block2|
+          parent_context.send(e, *args2, &block2)
         }
       }
       @before.each { |b| context.before(&b) }


### PR DESCRIPTION
Sometimes it is convenient to use a shared helper method which yields to a block (for example, in my case, it was a  method which takes a string and yields the string several times, each time with single character changed to something else). Unfortunately, Bacon currently doesn't support such helper methods defined within Bacon::Context instance and they have to be defined directly in Bacon::Context or in Object, simply because the blocks are not passed at all to the parent context.. The change above tries to fix this.