### PR TITLE
#22 without using block argument in a block

### DIFF
--- a/lib/bacon.rb
+++ b/lib/bacon.rb
@@ -215,12 +215,16 @@ module Bacon
       end
     end
 
+    class Proxy < Struct.new(:context, :name)
+      def call *args, &block
+        context.send(name, *args, &block)
+      end
+    end
+
     def describe(*args, &block)
       context = Bacon::Context.new(args.join(' '), &block)
-      (parent_context = self).methods(false).each {|e|
-        (class << context; self; end).send(:define_method, e) { |*args2, &block2|
-          parent_context.send(e, *args2, &block2)
-        }
+      methods(false).each {|e|
+        (class << context; self; end).send(:define_method, e, &Proxy.new(self, e).method(:call))
       }
       @before.each { |b| context.before(&b) }
       @after.each { |b| context.after(&b) }

--- a/lib/bacon.rb
+++ b/lib/bacon.rb
@@ -218,8 +218,8 @@ module Bacon
     def describe(*args, &block)
       context = Bacon::Context.new(args.join(' '), &block)
       (parent_context = self).methods(false).each {|e|
-        (class << context; self; end).send(:define_method, e) { |*args2|
-          parent_context.send(e, *args2)
+        (class << context; self; end).send(:define_method, e) { |*args2, &block2|
+          parent_context.send(e, *args2, &block2)
         }
       }
       @before.each { |b| context.before(&b) }

--- a/test/spec_bacon.rb
+++ b/test/spec_bacon.rb
@@ -375,6 +375,10 @@ describe "Methods" do
     42
   end
 
+  def the_towels
+    yield "DON'T PANIC"
+  end
+
   it "should be accessible in a test" do
     the_meaning_of_life.should == 42
   end
@@ -382,6 +386,12 @@ describe "Methods" do
   describe "when in a sibling context" do
     it "should be accessible in a test" do
       the_meaning_of_life.should == 42
+    end
+
+    it "should pass the block" do
+      the_towels do |label|
+        label.should == "DON'T PANIC"
+      end.should == true
     end
   end
 end


### PR DESCRIPTION
This could probably avoid syntax error in some older version of ruby...