### PR TITLE
Exit when signaled

### DIFF
--- a/lib/bacon.rb
+++ b/lib/bacon.rb
@@ -192,6 +192,8 @@ module Bacon
               raise e  unless rescued
             end
           end
+        rescue SystemExit, Interrupt
+          raise # Re-raise signal to kill the test run
         rescue Object => e
           ErrorLog << "#{e.class}: #{e.message}\n"
           e.backtrace.find_all { |line| line !~ /bin\/bacon|\/bacon\.rb:\d+/ }.


### PR DESCRIPTION
If you're running a large test suite and then realize something has gone horribly wrong (lots of test failures), then it's very difficult to kill the test run. The only way I've found so far is to to lookup the PID of the ruby process running `bacon` and kill it. This makes `bacon` gracefully handle being signaled with INT (Ctrl-C).

Without this change, sending INT just fails the current spec, since `SystemExit` and `Interrupt` are handle just like any other exception.