### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,20 @@ rvm:
 - 1.8.7
 - 1.9.2
 - 1.9.3
+- 2.0.0
+- 2.1.10
+- 2.2.7
+- 2.3.4
+- 2.4.1
+- ruby-head
 - rbx-18mode
 - rbx-19mode
 - jruby-18mode
 - jruby-19mode
+matrix:
+  allow_failures:
+    - rvm: ruby-head
+  fast_finish: true
 notifications:
   recipients:
   - gabriel.horner@gmail.com


### PR DESCRIPTION
Hello,

I want to update `.travis.yml` for Travis CI.

The reason I wanted to add `ruby-head` as `allow_failures` is
Because this is useful. we can prepare before next version Ruby 2.5 release.
Though it might not be useful until the actual preview release.
We can support the next version as faster.

We can see this kind of logic in `rails`, `rspec` and `cucumber` and etc.

https://github.com/rails/rails/blob/master/.travis.yml
https://github.com/rspec/rspec-core/blob/master/.travis.yml
https://github.com/cucumber/cucumber-ruby/blob/master/.travis.yml


fast_finish is to get the Travis result as faster without waiting the result of the "allow_failures" items.
See https://blog.travis-ci.com/2013-11-27-fast-finishing-builds/

Thanks.