### PR TITLE
Improve frozen-string-literals compatibility.

### DIFF
--- a/lib/bacon.rb
+++ b/lib/bacon.rb
@@ -11,7 +11,7 @@ module Bacon
   VERSION = "1.2"
 
   Counter = Hash.new(0)
-  ErrorLog = ""
+  ErrorLog = "".dup
   Shared = Hash.new { |_, name|
     raise NameError, "no such context: #{name.inspect}"
   }
@@ -337,7 +337,7 @@ class Should
   def method_missing(name, *args, &block)
     name = "#{name}?"  if name.to_s =~ /\w[^?]\z/
 
-    desc = @negated ? "not " : ""
+    desc = @negated ? "not ".dup : "".dup
     desc << @object.inspect << "." << name.to_s
     desc << "(" << args.map{|x|x.inspect}.join(", ") << ") failed"
 

--- a/test/spec_bacon.rb
+++ b/test/spec_bacon.rb
@@ -190,10 +190,10 @@ describe "Bacon" do
 
   it "should have should.be.identical_to/same_as" do
     lambda { s = "string"; s.should.be.identical_to s }.should succeed
-    lambda { "string".should.be.identical_to "string" }.should fail
+    lambda { "string".should.be.identical_to "string".dup }.should fail
 
     lambda { s = "string"; s.should.be.same_as s }.should succeed
-    lambda { "string".should.be.same_as "string" }.should fail
+    lambda { "string".should.be.same_as "string".dup }.should fail
   end
 
   it "should have should.respond_to" do


### PR DESCRIPTION
Only a few changes, but makes the tests pass when using MRI 2.4+ with the `RUBYOPT="--enable-frozen-string-literal"` flag set :)