### PR TITLE
README: Drop link to defunct BDD site

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -292,7 +292,6 @@ See COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 == Links
 
-Behavior-Driven Development:: <http://behaviour-driven.org/>
 RSpec:: <http://rspec.rubyforge.org/>
 test/spec:: <http://test-spec.rubyforge.org/>
 


### PR DESCRIPTION
This PR drops a link from the README.

  - the domain now hosts ad spam